### PR TITLE
Upgrade iconv version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "cheerio": "0.18.0",
     "generic-pool": "2.1.1",
-    "iconv": "2.1.4",
+    "iconv": "2.1.6",
     "iconv-lite": "0.4.4",
     "jschardet": "1.1.0",
     "lodash": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "chai": "1.9.2",
-    "mocha": "1.21.4",
+    "mocha": "2.2.1",
     "mocha-testdata": "1.1.0",
     "sinon": "1.11.1",
     "jsdom": "3.1.1"


### PR DESCRIPTION
Fixes #146 

Upgrade iconv version so that it works with node v0.12 as detailed in this commit: https://github.com/bnoordhuis/node-iconv/commit/ae0afa6abda10305a489e993ec9b747e22753f59

Similar upgrade to latest version of mocha to resolve this issue:
https://github.com/mochajs/mocha/pull/1364
https://github.com/mochajs/mocha/issues/1374
