### PR TITLE
Added response.bodyRAW that needed if server returns binary data

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -431,6 +431,7 @@ Crawler.prototype._onContent = function _onContent (error, options, response, fr
         }
 
     } else {
+        response.bodyRAW =response.body;
         response.body = response.body.toString();
     }
 


### PR DESCRIPTION
 Added response.bodyRAW that needed if server returns binary data instead of text response.
```
var crawler = new Crawler({
    callback: function (error, result, $) {
        if (result.headers['content-type'] == 'application/pdf'){//it's a PDF. Not text
                savePdf(result.bodyRAW).then(.....);
        }     
  }
});
```